### PR TITLE
Fix handling of Docker containers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The framework consists of four main components:
     ```
 
 
-## Citing DDOShiedl-IoT
+## Citing DDOShield-IoT
 
 If you use DDoShield-IoT in your research, please consider citing our paper to acknowledge the work we've put into the project. You can find our paper at the following link:
 

--- a/main.py
+++ b/main.py
@@ -601,14 +601,19 @@ def destroy():
             r_code = process("sudo modprobe -r ifb")
     print("DESTROYING ALL CONTAINERS")
 
-    r_containers = subprocess.check_output("docker ps -a -q", shell=True).decode('utf-8')
     r_code = 0
-    if r_containers:
-        r_containers = r_containers.strip().replace('\n',' ')
-        r_code = subprocess.call("docker stop %s && docker rm %s"%(r_containers, r_containers), shell=True)
-        check_return_code_chill(r_code, "Destroying ALL containers")
+    for x in range(1, numberOfNodes + 1):
+        r_code = process("docker stop %s && docker rm %s" % (nameList[x], nameList[x]), "Destroying container %s"%(nameList[x]), 0)
+        check_return_code_chill(r_code, "Destroying container %s"%(nameList[x]))
 
-    r_code = process("sudo /etc/init.d/docker restart")
+    # r_containers = subprocess.check_output("docker ps -a -q", shell=True).decode('utf-8')
+    # r_code = 0
+    # if r_containers:
+    #     r_containers = r_containers.strip().replace('\n',' ')
+    #     r_code = subprocess.call("docker stop %s && docker rm %s"%(r_containers, r_containers), shell=True)
+    #     check_return_code_chill(r_code, "Destroying ALL containers")
+
+    # r_code = process("sudo /etc/init.d/docker restart")
 
     docker_files = 0
     if os.path.exists(pidsDirectory):

--- a/main.py
+++ b/main.py
@@ -337,7 +337,7 @@ def create():
     acc_status = 0
 
     # TServer
-    acc_status += process('docker run --platform linux/amd64 -v %s/docker/videos:/var/www/html/ --restart=always --sysctl net.ipv6.conf.all.disable_ipv6=0 --privileged -dit --net=none --name %s %s' % (dir_path, nameList[1], 'tserver'), None, 1)
+    acc_status += process('docker run --platform linux/amd64 -v "%s"/docker/videos:/var/www/html/ --restart=always --sysctl net.ipv6.conf.all.disable_ipv6=0 --privileged -dit --net=none --name %s %s' % (dir_path, nameList[1], 'tserver'), None, 1)
 
     # Attacker
     acc_status = process('docker run --platform linux/amd64 --restart=always --sysctl net.ipv6.conf.all.disable_ipv6=0 --privileged -dit --net=none --name %s %s' % (nameList[2], baseContainerNameAtt), None, 1)
@@ -347,7 +347,7 @@ def create():
 
     # Devs
     for x in range(numberOfOthers + 1, (numberOfNodes + 1)):
-        acc_status += process("docker run --platform linux/amd64 -v %s/docker/videos:/data/ --restart=always --sysctl net.ipv6.conf.all.disable_ipv6=0 --privileged -dit --net=none --name %s %s" % (dir_path, nameList[x], baseContainerNameDnsm), None, 0)
+        acc_status += process('docker run --platform linux/amd64 -v "%s"/docker/videos:/data/ --restart=always --sysctl net.ipv6.conf.all.disable_ipv6=0 --privileged -dit --net=none --name %s %s' % (dir_path, nameList[x], baseContainerNameDnsm), None, 0)
 
     # If something went wrong running the docker containers, we panic and exit
     check_return_code(acc_status, "Running docker containers")
@@ -460,7 +460,7 @@ def ns3(code = 0):
         ns3_cmd = tmp.format(jobs, str(numberOfNodes), total_emu_time, churn, ns3FileLog, writeDirectory, numberOfOthers)
 
     print("NS3_HOME=%s && %s"% ((os.environ['NS3_HOME']).strip(), ns3_cmd))
- 
+
     try:
         p = getpass.getpass(prompt='Sudo password:')
     except Exception as error:
@@ -562,7 +562,7 @@ def run_emu():
     print('Letting the simulation run for %s' % emulationTimeStr)
 
     if exec_code == 1:
-        proc1.communicate() # proc1.wait() 
+        proc1.communicate() # proc1.wait()
     else:
         if os.path.exists(pidsDirectory + "ns3"):
             with open(pidsDirectory + "ns3", "rt") as in_file:


### PR DESCRIPTION
This pr fixes some oversights in the handling of the directory structure where the project files are located.

Space characters in the absolute path cause issues when escaped into the docker command and prevents the starting of the docker containers.

This pr also restricts the destruction part of the script to containers created by the script. We don't want to destroy ALL containers on the host system.

BEFORE THIS PR:
The program gracefully attempts to shut down with the following error message
"docker: invalid reference format: repository name must be lowercase.
See 'docker run --help'.
03e64edae609dbf5982cac5b55c968f51c2970ee9a202e1adc1881311e62e2b2
docker: invalid reference format: repository name must be lowercase.
See 'docker run --help'.
Error: Running docker containers

STOP! Please investigate the previous error(s) and run the command again
Destroying ...

DESTROYING ALL CONTAINERS"
...

AFTER THIS PR:
The program continues executing without issues.

